### PR TITLE
Fixing script running on iframes

### DIFF
--- a/EBA_Zoom_Link.user.js
+++ b/EBA_Zoom_Link.user.js
@@ -11,6 +11,7 @@
 // @match        http*://ders.eba.gov.tr/*
 // @connect      eba.gov.tr
 // @grant        GM_xmlhttpRequest
+// @noframes
 // @run-at       document-end
 // ==/UserScript==
 


### PR DESCRIPTION
Eba'da test çözerken ya da iframe kullanan diğer işlemlerde ders menusu gözükmekte tampermonkey dokumentasyonundan `@noframes` tag'ını ekleyince düzeldi.

LiveMiddleWare Kısmını test edeceğim, tahminim sıkıntı yaratmaz.
Öğretmen ve öğrenci ebası nerdeyse aynı orada da sıkıntı yaratacağını düşünmüyorum.

Tek çalışmayan şey öğretmenlerin dersi başlatması (#5 muhtemelen çözmeye yakınız), onun dışında görünüm dışında yapabileceğimiz pek işlem kalmadı. Belki tampermonkey yerine tarayıcılar için extension oluşturabiliriz.